### PR TITLE
Fix error when clearing of FileFields

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,38 +16,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Django 2.2
-          # - django: "2.2"
-          #   python: "3.6"
-          # - django: "2.2"
-          #   python: "3.7"
-          # - django: "2.2"
-          #   python: "3.8"
-          # - django: "2.2"
-          #   python: "3.9"
-          # # Django 3.1
-          # - django: "3.1"
-          #   python: "3.6"
-          # - django: "3.1"
-          #   python: "3.7"
-          # - django: "3.1"
-          #   python: "3.8"
-          # - django: "3.1"
-          #   python: "3.9"
-          # # Django 3.2
-          # - django: "3.2"
-          #   python: "3.6"
-          # - django: "3.2"
-          #   python: "3.7"
-          # - django: "3.2"
-          #   python: "3.8"
-          # - django: "3.2"
-          #   python: "3.9"
-          # - django: "3.2"
-          #   python: "3.10"
           # Django 4.2
           - django: "4.2"
             python: "3.9"
+          - django: "4.2"
+            python: "3.10"
+          # Django 5.0
+          - django: "5.0"
+            python: "3.10"
 
     steps:
       - name: Install gettext
@@ -71,3 +47,4 @@ jobs:
           echo "Python ${{ matrix.python }} / Django ${{ matrix.django }}"
           coverage run --rcfile=.coveragerc runtests.py
           codecov
+        continue-on-error: ${{ contains(matrix.django, '5.0') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,37 +17,37 @@ jobs:
       matrix:
         include:
           # Django 2.2
-          - django: "2.2"
-            python: "3.6"
-          - django: "2.2"
-            python: "3.7"
-          - django: "2.2"
-            python: "3.8"
-          - django: "2.2"
+          # - django: "2.2"
+          #   python: "3.6"
+          # - django: "2.2"
+          #   python: "3.7"
+          # - django: "2.2"
+          #   python: "3.8"
+          # - django: "2.2"
+          #   python: "3.9"
+          # # Django 3.1
+          # - django: "3.1"
+          #   python: "3.6"
+          # - django: "3.1"
+          #   python: "3.7"
+          # - django: "3.1"
+          #   python: "3.8"
+          # - django: "3.1"
+          #   python: "3.9"
+          # # Django 3.2
+          # - django: "3.2"
+          #   python: "3.6"
+          # - django: "3.2"
+          #   python: "3.7"
+          # - django: "3.2"
+          #   python: "3.8"
+          # - django: "3.2"
+          #   python: "3.9"
+          # - django: "3.2"
+          #   python: "3.10"
+          # Django 4.2
+          - django: "4.2"
             python: "3.9"
-          # Django 3.1
-          - django: "3.1"
-            python: "3.6"
-          - django: "3.1"
-            python: "3.7"
-          - django: "3.1"
-            python: "3.8"
-          - django: "3.1"
-            python: "3.9"
-          # Django 3.2
-          - django: "3.2"
-            python: "3.6"
-          - django: "3.2"
-            python: "3.7"
-          - django: "3.2"
-            python: "3.8"
-          - django: "3.2"
-            python: "3.9"
-          - django: "3.2"
-            python: "3.10"
-          # Django 4.0
-          - django: "4.0b1"
-            python: "3.10"
 
     steps:
       - name: Install gettext
@@ -71,4 +71,3 @@ jobs:
           echo "Python ${{ matrix.python }} / Django ${{ matrix.django }}"
           coverage run --rcfile=.coveragerc runtests.py
           codecov
-        continue-on-error: ${{ contains(matrix.django, '4.0') }}

--- a/parler/models.py
+++ b/parler/models.py
@@ -325,7 +325,7 @@ class TranslatableModelMixin:
                     # See: https://github.com/django-parler/django-parler/issues/326
                     model_field = parler_meta.model._meta.get_field(field)
                     model_field.save_form_data(translation, value)
-                except TypeError:
+                except (ValueError, TypeError) as e:
                     # TypeError signals a many to many field. We can't set it like the other attributes, so
                     # add to our own glued variable.
                     deferred_many_to_many = getattr(translation, "deferred_many_to_many", {})

--- a/parler/models.py
+++ b/parler/models.py
@@ -321,7 +321,10 @@ class TranslatableModelMixin:
             )
             for field, value in model_fields.items():
                 try:
-                    setattr(translation, field, value)
+                    # Fixed FileField clearing.
+                    # See: https://github.com/django-parler/django-parler/issues/326
+                    model_field = parler_meta.model._meta.get_field(field)
+                    model_field.save_form_data(translation, value)
                 except TypeError:
                     # TypeError signals a many to many field. We can't set it like the other attributes, so
                     # add to our own glued variable.

--- a/parler/tests/testapp/models.py
+++ b/parler/tests/testapp/models.py
@@ -44,6 +44,16 @@ class CleanFieldModel(TranslatableModel):
     def clean(self):
         self.shared += "_cleanshared"
 
+class FileFieldModel(TranslatableModel):
+    translations = TranslatedFields(
+        tr_file=models.FileField(
+            default="",
+            blank=True,
+        )
+    )
+
+    def __str__(self):
+        return self.tr_file
 
 class CleanFieldModelTranslation(TranslatedFieldsModel):
     master = TranslationsForeignKey(


### PR DESCRIPTION
When clearing a FileField, Django sets the value of the field to "False", which is a special case value (different than the normal "empty values"), that is supposed to inform the model to "clear" the property.  Parler unfortunatley does not know about this special case, when when it tries to simply set the attribute on the model, it converts the boolean `False` to the literal string "False", causing the database entity to be saved with the string "False".

NOTE: an added layer of complexity is introduced by the Parler Caching, because the cache layer retains the "Boolean" property of `False`, so when caching is enabled, it "appears" to work, because it will pull `False` from the cache (which is "falsey", similar to any empty values).  In order to observe this broken behaviour, the cache must be disabled (or cleared).

1. Added test reproduces the issue:
   ![image](https://github.com/user-attachments/assets/9d6257ec-b91f-43b7-96a6-0c3503075276)
2. Updated set operation to leverage the existing Django field custom logic.
